### PR TITLE
added workaround for header svg

### DIFF
--- a/css/components/header.css
+++ b/css/components/header.css
@@ -6,7 +6,12 @@ header {
   position: fixed;
   top: 0;
   background-image: url("../../images/background_shape_1.svg");
-  background-size: contain;
+
+  /* cover only works on svg viewport, content does not get stretched, even with preserveAspectRatio="none" in .svg */
+  background-size: cover;
+  /* background-repeat: no-repeat; */
+  background-position: bottom;
+
   height: 3.387rem;
   width: 100%;
   z-index: 100;

--- a/images/background_shape_1.svg
+++ b/images/background_shape_1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="375px" height="59px" viewBox="0 0 375 59" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="375" height="59" viewBox="0 0 375 59" preserveAspectRatio="none" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>background_shape_1</title>
     <g id="App" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="NF_CourseApp_Screen1" fill="#F8F8F8">


### PR DESCRIPTION
Das Hintergrund-Bild im Header wird jetzt nicht mehr unten abgeschnitten, wenn der Bildschirm breiter wird. Die Breite passt sich auch an.
Merkwürdig ist allerdings, dass das .svg offenbar immer sein Seitenverhältnis beibehält - deswegen sieht die kurvige Linie auf unterschiedlichen Bildschirmbreiten ein wenig anders aus.